### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/app/lambda-template.yaml
+++ b/app/lambda-template.yaml
@@ -44,7 +44,7 @@ Resources:
               console.log('Received event:', JSON.stringify(event));
               callback(null, JSON.stringify(event));
           };
-      Runtime: "nodejs6.10"
+      Runtime: "nodejs10.x"
       Timeout: "60"
       Role:
         Fn::GetAtt:

--- a/pipeline/codepipeline/codepipeline_template.yaml
+++ b/pipeline/codepipeline/codepipeline_template.yaml
@@ -86,7 +86,7 @@ Resources:
     Properties:
       FunctionName: StateMachineTriggerLambda
       Handler: state_machine_trigger.index
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt StateMachineTriggerLambdaRole.Arn

--- a/pipeline/statemachines/deploy/state_machine_template.yaml
+++ b/pipeline/statemachines/deploy/state_machine_template.yaml
@@ -85,7 +85,7 @@ Resources:
     Properties:
       FunctionName: CreateStackStateMachineTask
       Handler: create_stack.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt StateMachineLambdaRole.Arn
@@ -94,7 +94,7 @@ Resources:
     Properties:
       FunctionName: CheckStackExistsStateMachineTask
       Handler: check_stack_exists.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt StateMachineLambdaRole.Arn
@@ -103,7 +103,7 @@ Resources:
     Properties:
       FunctionName: CreateChangeSetStateMachineTask
       Handler: create_change_set.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt StateMachineLambdaRole.Arn
@@ -112,7 +112,7 @@ Resources:
     Properties:
       FunctionName: CheckStackCreationStatusStateMachineTask
       Handler: check_stack_creation_status.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt StateMachineLambdaRole.Arn
@@ -121,7 +121,7 @@ Resources:
     Properties:
       FunctionName: CheckChangeSetCreationStatusStateMachineTask
       Handler: check_change_set_creation_status.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt StateMachineLambdaRole.Arn
@@ -130,7 +130,7 @@ Resources:
     Properties:
       FunctionName: ExecuteChangeSetStateMachineTask
       Handler: execute_change_set.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt StateMachineLambdaRole.Arn
@@ -139,7 +139,7 @@ Resources:
     Properties:
       FunctionName: InspectChangeSetStateMachineTask
       Handler: inspect_change_set.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt StateMachineLambdaRole.Arn
@@ -148,7 +148,7 @@ Resources:
     Properties:
       FunctionName: DeleteChangeSetStateMachineTask
       Handler: delete_change_set.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: 128
       Timeout: 30
       Role: !GetAtt StateMachineLambdaRole.Arn


### PR DESCRIPTION
CloudFormation templates in aws-codepipeline-stepfunctions have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.